### PR TITLE
Fix categories endpoint parsing

### DIFF
--- a/app/src/main/java/pl/sofantastica/data/api/RetrofitApiService.kt
+++ b/app/src/main/java/pl/sofantastica/data/api/RetrofitApiService.kt
@@ -1,7 +1,6 @@
 package pl.sofantastica.data.api
 
 import pl.sofantastica.data.model.FurnitureDto
-import pl.sofantastica.data.model.CategoryDto
 import retrofit2.http.GET
 
 interface RetrofitApiService {
@@ -9,5 +8,5 @@ interface RetrofitApiService {
     suspend fun getFurniture(): List<FurnitureDto>
 
     @GET("sofantastic/furniture/categories")
-    suspend fun getCategories(): List<CategoryDto>
+    suspend fun getCategories(): List<String>
 }

--- a/app/src/main/java/pl/sofantastica/data/repository/FurnitureRepositoryImpl.kt
+++ b/app/src/main/java/pl/sofantastica/data/repository/FurnitureRepositoryImpl.kt
@@ -17,6 +17,6 @@ class FurnitureRepositoryImpl @Inject constructor(
     }
 
     override fun getCategories(): Flow<List<CategoryDto>> = flow {
-        emit(api.getCategories())
+        emit(api.getCategories().map { CategoryDto(it) })
     }
 }


### PR DESCRIPTION
## Summary
- handle the furniture categories endpoint returning plain strings

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6850343f6668832399e51d1c5f3a8350