### PR TITLE
Remove Flow usage and handle Retrofit responses

### DIFF
--- a/app/src/main/java/pl/sofantastica/data/api/RetrofitApiService.kt
+++ b/app/src/main/java/pl/sofantastica/data/api/RetrofitApiService.kt
@@ -1,12 +1,13 @@
 package pl.sofantastica.data.api
 
 import pl.sofantastica.data.model.FurnitureDto
+import retrofit2.Response
 import retrofit2.http.GET
 
 interface RetrofitApiService {
     @GET("sofantastic/furniture")
-    suspend fun getFurniture(): List<FurnitureDto>
+    suspend fun listFurniturs(): Response<List<FurnitureDto>>
 
     @GET("sofantastic/furniture/categories")
-    suspend fun getCategories(): List<String>
+    suspend fun listCategories(): Response<List<String>>
 }

--- a/app/src/main/java/pl/sofantastica/data/repository/FurnitureRepository.kt
+++ b/app/src/main/java/pl/sofantastica/data/repository/FurnitureRepository.kt
@@ -1,10 +1,9 @@
 package pl.sofantastica.data.repository
 
-import kotlinx.coroutines.flow.Flow
 import pl.sofantastica.data.model.FurnitureDto
 import pl.sofantastica.data.model.CategoryDto
 
 interface FurnitureRepository {
-    fun getFurniture(): Flow<List<FurnitureDto>>
-    fun getCategories(): Flow<List<CategoryDto>>
+    suspend fun getFurniture(): List<FurnitureDto>
+    suspend fun getCategories(): List<CategoryDto>
 }

--- a/app/src/main/java/pl/sofantastica/data/repository/FurnitureRepositoryImpl.kt
+++ b/app/src/main/java/pl/sofantastica/data/repository/FurnitureRepositoryImpl.kt
@@ -1,10 +1,9 @@
 package pl.sofantastica.data.repository
 
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
 import pl.sofantastica.data.api.RetrofitApiService
 import pl.sofantastica.data.model.FurnitureDto
 import pl.sofantastica.data.model.CategoryDto
+import retrofit2.HttpException
 import javax.inject.Inject
 
 
@@ -12,11 +11,31 @@ import javax.inject.Inject
 class FurnitureRepositoryImpl @Inject constructor(
     private val api: RetrofitApiService
 ) : FurnitureRepository {
-    override fun getFurniture(): Flow<List<FurnitureDto>> = flow {
-        emit(api.getFurniture())
+
+    override suspend fun getFurniture(): List<FurnitureDto> {
+        val response = try {
+            api.listFurniturs()
+        } catch (e: Exception) {
+            throw e
+        }
+        if (response.isSuccessful) {
+            val body = response.body()
+            if (body != null) return body
+        }
+        throw HttpException(response)
     }
 
-    override fun getCategories(): Flow<List<CategoryDto>> = flow {
-        emit(api.getCategories().map { CategoryDto(it) })
+    override suspend fun getCategories(): List<CategoryDto> {
+        val response = try {
+            api.listCategories()
+        } catch (e: Exception) {
+            throw e
+        }
+        if (response.isSuccessful) {
+            val body = response.body()
+            if (body != null) return body.map { CategoryDto(it) }
+        }
+        throw HttpException(response)
     }
 }
+

--- a/app/src/main/java/pl/sofantastica/ui/catalog/CatalogScreen.kt
+++ b/app/src/main/java/pl/sofantastica/ui/catalog/CatalogScreen.kt
@@ -8,10 +8,11 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
-import androidx.compose.runtime.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -21,9 +22,9 @@ import pl.sofantastica.data.model.FurnitureDto
 @Composable
 fun CatalogRoute(viewModel: CatalogViewModel = hiltViewModel()) {
     CatalogScreen(
-        furniture = viewModel.furniture.collectAsState(initial = emptyList()).value,
-        categories = viewModel.categories.collectAsState(initial = emptyList()).value,
-        selected = viewModel.selectedCategory.collectAsState(initial = null).value,
+        furniture = viewModel.furniture,
+        categories = viewModel.categories,
+        selected = viewModel.selectedCategory,
         onSelectCategory = viewModel::selectCategory
     )
 }
@@ -64,3 +65,4 @@ fun CatalogScreen(
         }
     }
 }
+


### PR DESCRIPTION
## Summary
- refactor RetrofitApiService to return Response objects
- update repository interface to use suspend functions
- implement error checking in repository implementation
- switch CatalogViewModel to Compose `mutableStateOf` instead of Flow
- simplify CatalogScreen to use state properties directly

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6850374e48d88323a2346c65b40868db