### PR TITLE
Implement favorites feature skeleton

### DIFF
--- a/app/src/main/java/pl/sofantastica/data/api/RetrofitApiService.kt
+++ b/app/src/main/java/pl/sofantastica/data/api/RetrofitApiService.kt
@@ -5,6 +5,8 @@ import pl.sofantastica.data.model.FabricDto
 import pl.sofantastica.data.model.OrderDto
 import retrofit2.Response
 import retrofit2.http.GET
+import retrofit2.http.POST
+import retrofit2.http.DELETE
 
 interface RetrofitApiService {
     @GET("sofantastic/furniture")
@@ -36,4 +38,25 @@ interface RetrofitApiService {
 
     @retrofit2.http.POST("sofantastic/order")
     suspend fun createOrder(@retrofit2.http.Body order: OrderDto): Response<OrderDto>
+
+    @GET("sofantastic/favorites/{userId}")
+    suspend fun listFavorites(@retrofit2.http.Path("userId") userId: String): Response<List<FurnitureDto>>
+
+    @GET("sofantastic/favorites/{userId}/{furnitureId}")
+    suspend fun isFavorite(
+        @retrofit2.http.Path("userId") userId: String,
+        @retrofit2.http.Path("furnitureId") furnitureId: Long
+    ): Response<Boolean>
+
+    @POST("sofantastic/favorites/{userId}/{furnitureId}")
+    suspend fun addFavorite(
+        @retrofit2.http.Path("userId") userId: String,
+        @retrofit2.http.Path("furnitureId") furnitureId: Long
+    ): Response<Unit>
+
+    @DELETE("sofantastic/favorites/{userId}/{furnitureId}")
+    suspend fun removeFavorite(
+        @retrofit2.http.Path("userId") userId: String,
+        @retrofit2.http.Path("furnitureId") furnitureId: Long
+    ): Response<Unit>
 }

--- a/app/src/main/java/pl/sofantastica/data/repository/FavoritesRepository.kt
+++ b/app/src/main/java/pl/sofantastica/data/repository/FavoritesRepository.kt
@@ -1,0 +1,10 @@
+package pl.sofantastica.data.repository
+
+import pl.sofantastica.data.model.FurnitureDto
+
+interface FavoritesRepository {
+    suspend fun getFavorites(userId: String): List<FurnitureDto>
+    suspend fun addFavorite(userId: String, furnitureId: Long)
+    suspend fun removeFavorite(userId: String, furnitureId: Long)
+    suspend fun isFavorite(userId: String, furnitureId: Long): Boolean
+}

--- a/app/src/main/java/pl/sofantastica/data/repository/FavoritesRepositoryImpl.kt
+++ b/app/src/main/java/pl/sofantastica/data/repository/FavoritesRepositoryImpl.kt
@@ -1,0 +1,40 @@
+package pl.sofantastica.data.repository
+
+import pl.sofantastica.data.api.RetrofitApiService
+import pl.sofantastica.data.model.FurnitureDto
+import retrofit2.HttpException
+import javax.inject.Inject
+
+class FavoritesRepositoryImpl @Inject constructor(
+    private val api: RetrofitApiService
+) : FavoritesRepository {
+    override suspend fun getFavorites(userId: String): List<FurnitureDto> {
+        val response = api.listFavorites(userId)
+        if (response.isSuccessful) {
+            return response.body() ?: emptyList()
+        }
+        throw HttpException(response)
+    }
+
+    override suspend fun addFavorite(userId: String, furnitureId: Long) {
+        val response = api.addFavorite(userId, furnitureId)
+        if (!response.isSuccessful) {
+            throw HttpException(response)
+        }
+    }
+
+    override suspend fun removeFavorite(userId: String, furnitureId: Long) {
+        val response = api.removeFavorite(userId, furnitureId)
+        if (!response.isSuccessful) {
+            throw HttpException(response)
+        }
+    }
+
+    override suspend fun isFavorite(userId: String, furnitureId: Long): Boolean {
+        val response = api.isFavorite(userId, furnitureId)
+        if (response.isSuccessful) {
+            return response.body() ?: false
+        }
+        throw HttpException(response)
+    }
+}

--- a/app/src/main/java/pl/sofantastica/di/RepositoryModule.kt
+++ b/app/src/main/java/pl/sofantastica/di/RepositoryModule.kt
@@ -10,6 +10,8 @@ import pl.sofantastica.data.repository.FabricRepository
 import pl.sofantastica.data.repository.FabricRepositoryImpl
 import pl.sofantastica.data.repository.OrderRepository
 import pl.sofantastica.data.repository.OrderRepositoryImpl
+import pl.sofantastica.data.repository.FavoritesRepository
+import pl.sofantastica.data.repository.FavoritesRepositoryImpl
 import javax.inject.Singleton
 
 @Module
@@ -32,4 +34,10 @@ abstract class RepositoryModule {
     abstract fun bindOrderRepository(
         impl: OrderRepositoryImpl
     ): OrderRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindFavoritesRepository(
+        impl: FavoritesRepositoryImpl
+    ): FavoritesRepository
 }

--- a/app/src/main/java/pl/sofantastica/domain/usecase/GetFavoritesUseCase.kt
+++ b/app/src/main/java/pl/sofantastica/domain/usecase/GetFavoritesUseCase.kt
@@ -1,0 +1,10 @@
+package pl.sofantastica.domain.usecase
+
+import pl.sofantastica.data.repository.FavoritesRepository
+import javax.inject.Inject
+
+class GetFavoritesUseCase @Inject constructor(
+    private val repository: FavoritesRepository
+) {
+    suspend operator fun invoke(userId: String) = repository.getFavorites(userId)
+}

--- a/app/src/main/java/pl/sofantastica/ui/MainScreen.kt
+++ b/app/src/main/java/pl/sofantastica/ui/MainScreen.kt
@@ -26,7 +26,7 @@ import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import pl.sofantastica.ui.catalog.CatalogRoute
 import pl.sofantastica.ui.home.HomeScreen
-import pl.sofantastica.ui.favorites.FavoritesScreen
+import pl.sofantastica.ui.favorites.FavoritesRoute
 import pl.sofantastica.ui.cart.CartScreen
 
 sealed class Screen(val route: String, val label: String, val icon: @Composable () -> Unit) {
@@ -43,7 +43,7 @@ fun MainScreen() {
     Box {
         NavHost(navController = navController, startDestination = Screen.Home.route) {
             composable(Screen.Home.route) { HomeScreen() }
-            composable(Screen.Favorites.route) { FavoritesScreen() }
+            composable(Screen.Favorites.route) { FavoritesRoute("demoUser") }
             composable(Screen.Catalog.route) { CatalogRoute() }
             composable(Screen.Cart.route) { CartScreen() }
             composable(Screen.More.route) { Text("More") }

--- a/app/src/main/java/pl/sofantastica/ui/favorites/FavoritesScreen.kt
+++ b/app/src/main/java/pl/sofantastica/ui/favorites/FavoritesScreen.kt
@@ -1,9 +1,36 @@
 package pl.sofantastica.ui.favorites
 
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
 
 @Composable
-fun FavoritesScreen() {
-    Text("Favorites")
+fun FavoritesRoute(userId: String, viewModel: FavoritesViewModel = hiltViewModel()) {
+    LaunchedEffect(userId) {
+        viewModel.load(userId)
+    }
+    FavoritesScreen(viewModel.favorites) { id ->
+        viewModel.toggleFavorite(userId, id)
+    }
+}
+
+@Composable
+fun FavoritesScreen(favorites: List<pl.sofantastica.data.model.FurnitureDto>, onToggle: (Long) -> Unit) {
+    Column(modifier = Modifier.padding(16.dp)) {
+        LazyColumn {
+            items(favorites) { item ->
+                Text(text = item.name, modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(8.dp))
+            }
+        }
+    }
 }

--- a/app/src/main/java/pl/sofantastica/ui/favorites/FavoritesViewModel.kt
+++ b/app/src/main/java/pl/sofantastica/ui/favorites/FavoritesViewModel.kt
@@ -1,8 +1,40 @@
 package pl.sofantastica.ui.favorites
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import pl.sofantastica.data.model.FurnitureDto
+import pl.sofantastica.data.repository.FavoritesRepository
+import pl.sofantastica.domain.usecase.GetFavoritesUseCase
 import javax.inject.Inject
 
 @HiltViewModel
-class FavoritesViewModel @Inject constructor() : ViewModel()
+class FavoritesViewModel @Inject constructor(
+    private val getFavorites: GetFavoritesUseCase,
+    private val repo: FavoritesRepository
+) : ViewModel() {
+
+    var favorites: List<FurnitureDto> = emptyList()
+        private set
+
+    fun load(userId: String) {
+        viewModelScope.launch {
+            favorites = try {
+                getFavorites(userId)
+            } catch (_: Exception) {
+                emptyList()
+            }
+        }
+    }
+
+    fun toggleFavorite(userId: String, furnitureId: Long) {
+        viewModelScope.launch {
+            val isFav = try { repo.isFavorite(userId, furnitureId) } catch (_: Exception) { false }
+            try {
+                if (isFav) repo.removeFavorite(userId, furnitureId) else repo.addFavorite(userId, furnitureId)
+                load(userId)
+            } catch (_: Exception) { }
+        }
+    }
+}

--- a/app/src/test/java/pl/sofantastica/data/repository/FavoritesRepositoryImplTest.kt
+++ b/app/src/test/java/pl/sofantastica/data/repository/FavoritesRepositoryImplTest.kt
@@ -1,0 +1,59 @@
+package pl.sofantastica.data.repository
+
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import pl.sofantastica.data.api.RetrofitApiService
+import pl.sofantastica.data.model.FurnitureDto
+import retrofit2.Response
+
+class FavoritesRepositoryImplTest {
+    private val favorites = listOf(
+        FurnitureDto(1, "Chair", 50.0, "desc", "img", emptyList(), "model", "chairs"),
+        FurnitureDto(2, "Table", 80.0, "desc", "img", emptyList(), "model", "tables")
+    )
+
+    private var added = mutableListOf<FurnitureDto>()
+
+    private val api = object : RetrofitApiService {
+        override suspend fun listFavorites(userId: String): Response<List<FurnitureDto>> = Response.success(favorites + added)
+        override suspend fun isFavorite(userId: String, furnitureId: Long): Response<Boolean> =
+            Response.success((favorites + added).any { it.id.toLong() == furnitureId })
+        override suspend fun addFavorite(userId: String, furnitureId: Long): Response<Unit> {
+            added.add(FurnitureDto(furnitureId.toInt(), "New", 0.0, "", "", emptyList(), "", ""))
+            return Response.success(Unit)
+        }
+        override suspend fun removeFavorite(userId: String, furnitureId: Long): Response<Unit> {
+            added.removeAll { it.id.toLong() == furnitureId }
+            return Response.success(Unit)
+        }
+        override suspend fun listFurniturs(): Response<List<FurnitureDto>> = Response.success(emptyList())
+        override suspend fun listCategories(): Response<List<String>> = Response.success(emptyList())
+        override suspend fun getFurnitureDetail(id: Int): Response<FurnitureDto> = Response.success(favorites.first())
+        override suspend fun listFabrics(): Response<List<pl.sofantastica.data.model.FabricDto>> = throw UnsupportedOperationException()
+        override suspend fun getFabricDetail(id: Int): Response<pl.sofantastica.data.model.FabricDto> = throw UnsupportedOperationException()
+        override suspend fun listSuppliers(): Response<List<String>> = throw UnsupportedOperationException()
+        override suspend fun listFabricsBySupplier(supplier: String): Response<List<pl.sofantastica.data.model.FabricDto>> = throw UnsupportedOperationException()
+        override suspend fun listPopularFabrics(): Response<List<pl.sofantastica.data.model.FabricDto>> = throw UnsupportedOperationException()
+        override suspend fun listOrders(userId: String): Response<List<pl.sofantastica.data.model.OrderDto>> = throw UnsupportedOperationException()
+        override suspend fun createOrder(order: pl.sofantastica.data.model.OrderDto): Response<pl.sofantastica.data.model.OrderDto> = throw UnsupportedOperationException()
+    }
+
+    private val repository = FavoritesRepositoryImpl(api)
+
+    @Test
+    fun getFavorites_returnsList() = runBlocking {
+        val result = repository.getFavorites("u1")
+        assertEquals(2, result.size)
+    }
+
+    @Test
+    fun addAndRemoveFavorite_modifiesList() = runBlocking {
+        repository.addFavorite("u1", 5)
+        var list = repository.getFavorites("u1")
+        assertEquals(3, list.size)
+        repository.removeFavorite("u1", 5)
+        list = repository.getFavorites("u1")
+        assertEquals(2, list.size)
+    }
+}

--- a/app/src/test/java/pl/sofantastica/domain/usecase/GetFavoritesUseCaseTest.kt
+++ b/app/src/test/java/pl/sofantastica/domain/usecase/GetFavoritesUseCaseTest.kt
@@ -1,0 +1,27 @@
+package pl.sofantastica.domain.usecase
+
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import pl.sofantastica.data.model.FurnitureDto
+import pl.sofantastica.data.repository.FavoritesRepository
+
+class GetFavoritesUseCaseTest {
+    private val repo = object : FavoritesRepository {
+        override suspend fun getFavorites(userId: String) = listOf(
+            FurnitureDto(1, "Chair", 0.0, "", "", emptyList(), "", "")
+        )
+        override suspend fun addFavorite(userId: String, furnitureId: Long) {}
+        override suspend fun removeFavorite(userId: String, furnitureId: Long) {}
+        override suspend fun isFavorite(userId: String, furnitureId: Long) = false
+    }
+
+    private val useCase = GetFavoritesUseCase(repo)
+
+    @Test
+    fun invoke_returnsList() = runBlocking {
+        val result = useCase("u1")
+        assertEquals(1, result.size)
+        assertEquals("Chair", result.first().name)
+    }
+}


### PR DESCRIPTION
## Summary
- add Retrofit endpoints and repository for Favorites
- provide Hilt binding for new repository
- implement `FavoritesViewModel` and compose screens
- update navigation to show favorites
- add unit tests for new repository and use case

## Testing
- `./gradlew test --quiet` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685046c8461c8323aac171769aae6a6f