### PR TITLE
Implement cart API skeleton

### DIFF
--- a/app/src/main/java/pl/sofantastica/data/api/RetrofitApiService.kt
+++ b/app/src/main/java/pl/sofantastica/data/api/RetrofitApiService.kt
@@ -3,6 +3,11 @@ package pl.sofantastica.data.api
 import pl.sofantastica.data.model.FurnitureDto
 import pl.sofantastica.data.model.FabricDto
 import pl.sofantastica.data.model.OrderDto
+import pl.sofantastica.data.model.PriceDto
+import pl.sofantastica.data.model.CartItemDto
+import pl.sofantastica.data.model.AddCartItemResponse
+import pl.sofantastica.data.model.CartItemUpdateDto
+import pl.sofantastica.data.model.SuccessResponse
 import retrofit2.Response
 import retrofit2.http.GET
 import retrofit2.http.POST
@@ -32,6 +37,33 @@ interface RetrofitApiService {
 
     @GET("sofantastic/fabric/popular")
     suspend fun listPopularFabrics(): Response<List<FabricDto>>
+
+    @GET("sofantastic/price")
+    suspend fun getPrice(
+        @retrofit2.http.Query("furnitureId") furnitureId: Int,
+        @retrofit2.http.Query("fabricId") fabricId: Int
+    ): Response<PriceDto>
+
+    @GET("sofantastic/cart/{userId}")
+    suspend fun getCart(
+        @retrofit2.http.Path("userId") userId: String
+    ): Response<List<CartItemDto>>
+
+    @POST("sofantastic/cart")
+    suspend fun addCartItem(
+        @retrofit2.http.Body item: CartItemDto
+    ): Response<AddCartItemResponse>
+
+    @retrofit2.http.PATCH("sofantastic/cart/{cartItemId}/color_and_quantity")
+    suspend fun updateCartItem(
+        @retrofit2.http.Path("cartItemId") cartItemId: Int,
+        @retrofit2.http.Body item: CartItemUpdateDto
+    ): Response<SuccessResponse>
+
+    @DELETE("sofantastic/cart/{id}")
+    suspend fun deleteCartItem(
+        @retrofit2.http.Path("id") id: Int
+    ): Response<Unit>
 
     @GET("sofantastic/order/{userId}")
     suspend fun listOrders(@retrofit2.http.Path("userId") userId: String): Response<List<OrderDto>>

--- a/app/src/main/java/pl/sofantastica/data/model/AddCartItemResponse.kt
+++ b/app/src/main/java/pl/sofantastica/data/model/AddCartItemResponse.kt
@@ -1,0 +1,5 @@
+package pl.sofantastica.data.model
+
+data class AddCartItemResponse(
+    val cartItemId: Int
+)

--- a/app/src/main/java/pl/sofantastica/data/model/CartItemDto.kt
+++ b/app/src/main/java/pl/sofantastica/data/model/CartItemDto.kt
@@ -1,0 +1,9 @@
+package pl.sofantastica.data.model
+
+data class CartItemDto(
+    val id: Int? = null,
+    val userId: String,
+    val productId: Int,
+    val quantity: Int,
+    val fabricId: Int
+)

--- a/app/src/main/java/pl/sofantastica/data/model/CartItemUpdateDto.kt
+++ b/app/src/main/java/pl/sofantastica/data/model/CartItemUpdateDto.kt
@@ -1,0 +1,6 @@
+package pl.sofantastica.data.model
+
+data class CartItemUpdateDto(
+    val quantity: Int,
+    val fabricId: Int
+)

--- a/app/src/main/java/pl/sofantastica/data/model/PriceDto.kt
+++ b/app/src/main/java/pl/sofantastica/data/model/PriceDto.kt
@@ -1,0 +1,5 @@
+package pl.sofantastica.data.model
+
+data class PriceDto(
+    val price: Double
+)

--- a/app/src/main/java/pl/sofantastica/data/model/SuccessResponse.kt
+++ b/app/src/main/java/pl/sofantastica/data/model/SuccessResponse.kt
@@ -1,0 +1,5 @@
+package pl.sofantastica.data.model
+
+data class SuccessResponse(
+    val success: Boolean
+)

--- a/app/src/main/java/pl/sofantastica/data/repository/CartRepository.kt
+++ b/app/src/main/java/pl/sofantastica/data/repository/CartRepository.kt
@@ -1,0 +1,11 @@
+package pl.sofantastica.data.repository
+
+import pl.sofantastica.data.model.CartItemDto
+import pl.sofantastica.data.model.CartItemUpdateDto
+
+interface CartRepository {
+    suspend fun getCart(userId: String): List<CartItemDto>
+    suspend fun addItem(item: CartItemDto): Int
+    suspend fun updateItem(id: Int, item: CartItemUpdateDto)
+    suspend fun deleteItem(id: Int)
+}

--- a/app/src/main/java/pl/sofantastica/data/repository/CartRepositoryImpl.kt
+++ b/app/src/main/java/pl/sofantastica/data/repository/CartRepositoryImpl.kt
@@ -1,0 +1,43 @@
+package pl.sofantastica.data.repository
+
+import pl.sofantastica.data.api.RetrofitApiService
+import pl.sofantastica.data.model.CartItemDto
+import pl.sofantastica.data.model.CartItemUpdateDto
+import retrofit2.HttpException
+import javax.inject.Inject
+
+class CartRepositoryImpl @Inject constructor(
+    private val api: RetrofitApiService
+) : CartRepository {
+
+    override suspend fun getCart(userId: String): List<CartItemDto> {
+        val response = api.getCart(userId)
+        if (response.isSuccessful) {
+            return response.body() ?: emptyList()
+        }
+        throw HttpException(response)
+    }
+
+    override suspend fun addItem(item: CartItemDto): Int {
+        val response = api.addCartItem(item)
+        if (response.isSuccessful) {
+            val body = response.body()
+            if (body != null) return body.cartItemId
+        }
+        throw HttpException(response)
+    }
+
+    override suspend fun updateItem(id: Int, item: CartItemUpdateDto) {
+        val response = api.updateCartItem(id, item)
+        if (!response.isSuccessful) {
+            throw HttpException(response)
+        }
+    }
+
+    override suspend fun deleteItem(id: Int) {
+        val response = api.deleteCartItem(id)
+        if (!response.isSuccessful) {
+            throw HttpException(response)
+        }
+    }
+}

--- a/app/src/main/java/pl/sofantastica/di/RepositoryModule.kt
+++ b/app/src/main/java/pl/sofantastica/di/RepositoryModule.kt
@@ -12,6 +12,8 @@ import pl.sofantastica.data.repository.OrderRepository
 import pl.sofantastica.data.repository.OrderRepositoryImpl
 import pl.sofantastica.data.repository.FavoritesRepository
 import pl.sofantastica.data.repository.FavoritesRepositoryImpl
+import pl.sofantastica.data.repository.CartRepository
+import pl.sofantastica.data.repository.CartRepositoryImpl
 import javax.inject.Singleton
 
 @Module
@@ -40,4 +42,10 @@ abstract class RepositoryModule {
     abstract fun bindFavoritesRepository(
         impl: FavoritesRepositoryImpl
     ): FavoritesRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindCartRepository(
+        impl: CartRepositoryImpl
+    ): CartRepository
 }

--- a/app/src/main/java/pl/sofantastica/domain/usecase/GetCartUseCase.kt
+++ b/app/src/main/java/pl/sofantastica/domain/usecase/GetCartUseCase.kt
@@ -1,0 +1,10 @@
+package pl.sofantastica.domain.usecase
+
+import pl.sofantastica.data.repository.CartRepository
+import javax.inject.Inject
+
+class GetCartUseCase @Inject constructor(
+    private val repository: CartRepository
+) {
+    suspend operator fun invoke(userId: String) = repository.getCart(userId)
+}

--- a/app/src/main/java/pl/sofantastica/ui/MainScreen.kt
+++ b/app/src/main/java/pl/sofantastica/ui/MainScreen.kt
@@ -27,7 +27,7 @@ import androidx.navigation.compose.rememberNavController
 import pl.sofantastica.ui.catalog.CatalogRoute
 import pl.sofantastica.ui.home.HomeScreen
 import pl.sofantastica.ui.favorites.FavoritesRoute
-import pl.sofantastica.ui.cart.CartScreen
+import pl.sofantastica.ui.cart.CartRoute
 
 sealed class Screen(val route: String, val label: String, val icon: @Composable () -> Unit) {
     object Home : Screen("home", "Home", { Icon(Icons.Default.Home, contentDescription = null) })
@@ -45,7 +45,7 @@ fun MainScreen() {
             composable(Screen.Home.route) { HomeScreen() }
             composable(Screen.Favorites.route) { FavoritesRoute("demoUser") }
             composable(Screen.Catalog.route) { CatalogRoute() }
-            composable(Screen.Cart.route) { CartScreen() }
+            composable(Screen.Cart.route) { CartRoute("demoUser") }
             composable(Screen.More.route) { Text("More") }
         }
         NavigationBar(modifier = Modifier.align(androidx.compose.ui.Alignment.BottomCenter)) {

--- a/app/src/main/java/pl/sofantastica/ui/cart/CartScreen.kt
+++ b/app/src/main/java/pl/sofantastica/ui/cart/CartScreen.kt
@@ -1,9 +1,39 @@
 package pl.sofantastica.ui.cart
 
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Button
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import pl.sofantastica.data.model.CartItemDto
 
 @Composable
-fun CartScreen() {
-    Text("Cart")
+fun CartRoute(userId: String, viewModel: CartViewModel = hiltViewModel()) {
+    LaunchedEffect(userId) { viewModel.load(userId) }
+    CartScreen(viewModel.items) { id -> viewModel.removeItem(id, userId) }
+}
+
+@Composable
+fun CartScreen(items: List<CartItemDto>, onDelete: (Int) -> Unit) {
+    Column(modifier = Modifier.padding(16.dp)) {
+        LazyColumn {
+            items(items) { item ->
+                Column(modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(8.dp)) {
+                    Text("Product ${'$'}{item.productId} qty ${'$'}{item.quantity}")
+                    Button(onClick = { item.id?.let(onDelete) }) {
+                        Text("Remove")
+                    }
+                }
+            }
+        }
+    }
 }

--- a/app/src/main/java/pl/sofantastica/ui/cart/CartViewModel.kt
+++ b/app/src/main/java/pl/sofantastica/ui/cart/CartViewModel.kt
@@ -1,8 +1,43 @@
 package pl.sofantastica.ui.cart
 
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import pl.sofantastica.data.model.CartItemDto
+import pl.sofantastica.data.repository.CartRepository
+import pl.sofantastica.domain.usecase.GetCartUseCase
 import javax.inject.Inject
 
 @HiltViewModel
-class CartViewModel @Inject constructor() : ViewModel()
+class CartViewModel @Inject constructor(
+    private val getCart: GetCartUseCase,
+    private val repository: CartRepository
+) : ViewModel() {
+
+    var items by mutableStateOf<List<CartItemDto>>(emptyList())
+        private set
+
+    fun load(userId: String) {
+        viewModelScope.launch {
+            items = try {
+                getCart(userId)
+            } catch (_: Exception) {
+                emptyList()
+            }
+        }
+    }
+
+    fun removeItem(id: Int, userId: String) {
+        viewModelScope.launch {
+            try {
+                repository.deleteItem(id)
+                load(userId)
+            } catch (_: Exception) {
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- define cart-related DTOs and repository
- expand Retrofit service with cart and price endpoints
- provide GetCartUseCase and CartViewModel logic
- add simple CartScreen displaying cart items
- bind CartRepository with Hilt
- wire CartRoute in `MainScreen`

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68504bf36a888323876aa3c1298a4924