### PR TITLE
Implement catalog details and persistent nav bar

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -78,4 +78,5 @@ dependencies {
     implementation(libs.firebase.firestore)
     implementation(libs.firebase.storage)
     implementation(libs.firebase.config)
+    implementation(libs.coil.compose)
 }

--- a/app/src/main/java/pl/sofantastica/ui/MainScreen.kt
+++ b/app/src/main/java/pl/sofantastica/ui/MainScreen.kt
@@ -3,6 +3,7 @@ package pl.sofantastica.ui
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.Favorite
@@ -12,18 +13,20 @@ import androidx.compose.material.icons.filled.List
 import androidx.compose.material3.Icon
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.Alignment
 import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
+import androidx.navigation.compose.navArgument
+import androidx.navigation.NavType
 import pl.sofantastica.ui.catalog.CatalogRoute
 import pl.sofantastica.ui.home.HomeScreen
 import pl.sofantastica.ui.favorites.FavoritesRoute
@@ -40,35 +43,50 @@ sealed class Screen(val route: String, val label: String, val icon: @Composable 
 @Composable
 fun MainScreen() {
     val navController = rememberNavController()
-    Box {
-        NavHost(navController = navController, startDestination = Screen.Home.route) {
+    Scaffold(
+        modifier = Modifier.fillMaxSize(),
+        bottomBar = {
+            NavigationBar {
+                val backStackEntry by navController.currentBackStackEntryAsState()
+                val currentDestination = backStackEntry?.destination?.route
+                val items = listOf(Screen.Home, Screen.Favorites, Screen.Catalog, Screen.Cart, Screen.More)
+                items.forEach { screen ->
+                    val selected = currentDestination == screen.route
+                    val iconModifier = if (screen == Screen.Catalog) Modifier
+                        .padding(vertical = 4.dp)
+                        .size(36.dp) else Modifier.size(24.dp)
+                    NavigationBarItem(
+                        selected = selected,
+                        onClick = {
+                            navController.navigate(screen.route) {
+                                popUpTo(navController.graph.findStartDestination().id) { saveState = true }
+                                launchSingleTop = true
+                                restoreState = true
+                            }
+                        },
+                        icon = { Box(modifier = iconModifier) { screen.icon() } },
+                        label = { Text(screen.label) }
+                    )
+                }
+            }
+        }
+    ) { innerPadding ->
+        NavHost(
+            navController = navController,
+            startDestination = Screen.Home.route,
+            modifier = Modifier.padding(innerPadding)
+        ) {
             composable(Screen.Home.route) { HomeScreen() }
             composable(Screen.Favorites.route) { FavoritesRoute("demoUser") }
-            composable(Screen.Catalog.route) { CatalogRoute() }
+            composable(Screen.Catalog.route) { CatalogRoute(onItemClick = { id -> navController.navigate("detail/$id") }) }
             composable(Screen.Cart.route) { CartRoute("demoUser") }
             composable(Screen.More.route) { Text("More") }
-        }
-        NavigationBar(modifier = Modifier.align(androidx.compose.ui.Alignment.BottomCenter)) {
-            val backStackEntry by navController.currentBackStackEntryAsState()
-            val currentDestination = backStackEntry?.destination?.route
-            val items = listOf(Screen.Home, Screen.Favorites, Screen.Catalog, Screen.Cart, Screen.More)
-            items.forEach { screen ->
-                val selected = currentDestination == screen.route
-                val iconModifier = if (screen == Screen.Catalog) Modifier
-                    .padding(vertical = 4.dp)
-                    .size(36.dp) else Modifier.size(24.dp)
-                NavigationBarItem(
-                    selected = selected,
-                    onClick = {
-                        navController.navigate(screen.route) {
-                            popUpTo(navController.graph.findStartDestination().id) { saveState = true }
-                            launchSingleTop = true
-                            restoreState = true
-                        }
-                    },
-                    icon = { Box(modifier = iconModifier) { screen.icon() } },
-                    label = { Text(screen.label) }
-                )
+            composable(
+                route = "detail/{id}",
+                arguments = listOf(navArgument("id") { type = NavType.IntType })
+            ) { backStackEntry ->
+                val id = backStackEntry.arguments?.getInt("id") ?: return@composable
+                pl.sofantastica.ui.detail.FurnitureDetailRoute(id)
             }
         }
     }

--- a/app/src/main/java/pl/sofantastica/ui/catalog/CatalogScreen.kt
+++ b/app/src/main/java/pl/sofantastica/ui/catalog/CatalogScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.clickable
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -20,12 +21,16 @@ import pl.sofantastica.data.model.CategoryDto
 import pl.sofantastica.data.model.FurnitureDto
 
 @Composable
-fun CatalogRoute(viewModel: CatalogViewModel = hiltViewModel()) {
+fun CatalogRoute(
+    onItemClick: (Int) -> Unit,
+    viewModel: CatalogViewModel = hiltViewModel()
+) {
     CatalogScreen(
         furniture = viewModel.furniture,
         categories = viewModel.categories,
         selected = viewModel.selectedCategory,
-        onSelectCategory = viewModel::selectCategory
+        onSelectCategory = viewModel::selectCategory,
+        onItemClick = onItemClick
     )
 }
 
@@ -35,7 +40,8 @@ fun CatalogScreen(
     furniture: List<FurnitureDto>,
     categories: List<CategoryDto>,
     selected: CategoryDto?,
-    onSelectCategory: (CategoryDto?) -> Unit
+    onSelectCategory: (CategoryDto?) -> Unit,
+    onItemClick: (Int) -> Unit
 ) {
     Column(modifier = Modifier.padding(16.dp)) {
         val expanded = remember { mutableStateOf(false) }
@@ -58,9 +64,13 @@ fun CatalogScreen(
 
         LazyColumn {
             items(furniture) { item ->
-                Text(text = item.name, modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(8.dp))
+                Text(
+                    text = item.name,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable { onItemClick(item.id) }
+                        .padding(8.dp)
+                )
             }
         }
     }

--- a/app/src/main/java/pl/sofantastica/ui/detail/FurnitureDetailScreen.kt
+++ b/app/src/main/java/pl/sofantastica/ui/detail/FurnitureDetailScreen.kt
@@ -1,9 +1,38 @@
 package pl.sofantastica.ui.detail
 
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import pl.sofantastica.data.model.FurnitureDto
 
 @Composable
-fun FurnitureDetailScreen(id: Int) {
-    Text("Furniture Detail $id")
+fun FurnitureDetailScreen(item: FurnitureDto) {
+    Column(modifier = Modifier.padding(16.dp)) {
+        AsyncImage(
+            model = item.imageUrl,
+            contentDescription = item.name,
+            modifier = Modifier.fillMaxWidth()
+        )
+        Text(text = item.name, modifier = Modifier.padding(top = 8.dp))
+        Text(text = item.description, modifier = Modifier.padding(top = 4.dp))
+    }
+}
+
+@Composable
+fun FurnitureDetailRoute(
+    id: Int,
+    viewModel: FurnitureDetailViewModel = androidx.hilt.navigation.compose.hiltViewModel()
+) {
+    androidx.compose.runtime.LaunchedEffect(id) { viewModel.load(id) }
+    when (val state = viewModel.uiState) {
+        pl.sofantastica.ui.common.UiState.Loading -> Text("Loading...")
+        is pl.sofantastica.ui.common.UiState.Error -> Text("Error: ${state.throwable.message}")
+        is pl.sofantastica.ui.common.UiState.Success -> FurnitureDetailScreen(state.data)
+    }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,6 +18,7 @@ moshi = "1.15.0"
 coroutines = "1.7.3"
 room = "2.6.1"
 firebaseBom = "33.1.0"
+coil = "2.6.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -54,6 +55,7 @@ firebase-auth = { group = "com.google.firebase", name = "firebase-auth-ktx" }
 firebase-firestore = { group = "com.google.firebase", name = "firebase-firestore-ktx" }
 firebase-storage = { group = "com.google.firebase", name = "firebase-storage-ktx" }
 firebase-config = { group = "com.google.firebase", name = "firebase-config-ktx" }
+coil-compose = { group = "io.coil-kt", name = "coil-compose", version.ref = "coil" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- keep bottom navigation in a `Scaffold` so it stays anchored
- allow selecting furniture from catalog to open detail screen
- show furniture image and info using Coil
- add Coil dependency

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68504e0fef2c8323971c7cb29a14b890