### PR TITLE
Fix detail screen loading

### DIFF
--- a/app/src/main/java/pl/sofantastica/ui/MainScreen.kt
+++ b/app/src/main/java/pl/sofantastica/ui/MainScreen.kt
@@ -86,9 +86,8 @@ fun MainScreen() {
             composable(
                 route = "detail/{id}",
                 arguments = listOf(navArgument("id") { type = NavType.IntType })
-            ) { backStackEntry ->
-                val id = backStackEntry.arguments?.getInt("id") ?: return@composable
-               FurnitureDetailRoute(id)
+            ) {
+                FurnitureDetailRoute()
             }
         }
     }

--- a/app/src/main/java/pl/sofantastica/ui/detail/FurnitureDetailScreen.kt
+++ b/app/src/main/java/pl/sofantastica/ui/detail/FurnitureDetailScreen.kt
@@ -5,7 +5,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
+
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
@@ -15,12 +15,8 @@ import pl.sofantastica.ui.common.UiState
 
 @Composable
 fun FurnitureDetailRoute(
-    id: Int,
     viewModel: FurnitureDetailViewModel = androidx.hilt.navigation.compose.hiltViewModel()
 ) {
-    LaunchedEffect(id) {
-        viewModel.load(id)
-    }
     when (val state = viewModel.uiState) {
         is UiState.Loading -> Text("Loading...")
         is UiState.Error -> Text("Error: ${state.throwable.message}")

--- a/app/src/main/java/pl/sofantastica/ui/detail/FurnitureDetailViewModel.kt
+++ b/app/src/main/java/pl/sofantastica/ui/detail/FurnitureDetailViewModel.kt
@@ -3,6 +3,7 @@ package pl.sofantastica.ui.detail
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -14,11 +15,16 @@ import javax.inject.Inject
 
 @HiltViewModel
 class FurnitureDetailViewModel @Inject constructor(
-    private val getDetail: GetFurnitureDetailUseCase
+    private val getDetail: GetFurnitureDetailUseCase,
+    savedStateHandle: SavedStateHandle
 ) : ViewModel() {
 
     var uiState by mutableStateOf<UiState<FurnitureDto>>(UiState.Loading)
         private set
+
+    init {
+        savedStateHandle.get<Int>("id")?.let { load(it) }
+    }
 
     fun load(id: Int) {
         viewModelScope.launch {


### PR DESCRIPTION
## Summary
- load furniture detail using `SavedStateHandle`
- simplify detail route composable

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685071d9f3208323a287e597dbd0e5cf