### PR TITLE
Hide bottom bar in detail view

### DIFF
--- a/app/src/main/java/pl/sofantastica/ui/MainScreen.kt
+++ b/app/src/main/java/pl/sofantastica/ui/MainScreen.kt
@@ -47,27 +47,30 @@ fun MainScreen() {
     Scaffold(
         modifier = Modifier.fillMaxSize(),
         bottomBar = {
-            NavigationBar {
-                val backStackEntry by navController.currentBackStackEntryAsState()
-                val currentDestination = backStackEntry?.destination?.route
-                val items = listOf(Screen.Home, Screen.Favorites, Screen.Catalog, Screen.Cart, Screen.More)
-                items.forEach { screen ->
-                    val selected = currentDestination == screen.route
-                    val iconModifier = if (screen == Screen.Catalog) Modifier
-                        .padding(vertical = 4.dp)
-                        .size(36.dp) else Modifier.size(24.dp)
-                    NavigationBarItem(
-                        selected = selected,
-                        onClick = {
-                            navController.navigate(screen.route) {
-                                popUpTo(navController.graph.findStartDestination().id) { saveState = true }
-                                launchSingleTop = true
-                                restoreState = true
-                            }
-                        },
-                        icon = { Box(modifier = iconModifier) { screen.icon() } },
-                        label = { Text(screen.label) }
-                    )
+            val backStackEntry by navController.currentBackStackEntryAsState()
+            val currentRoute = backStackEntry?.destination?.route
+            val showBottom = currentRoute?.startsWith("detail") != true
+            if (showBottom) {
+                NavigationBar {
+                    val items = listOf(Screen.Home, Screen.Favorites, Screen.Catalog, Screen.Cart, Screen.More)
+                    items.forEach { screen ->
+                        val selected = currentRoute == screen.route
+                        val iconModifier = if (screen == Screen.Catalog) Modifier
+                            .padding(vertical = 4.dp)
+                            .size(36.dp) else Modifier.size(24.dp)
+                        NavigationBarItem(
+                            selected = selected,
+                            onClick = {
+                                navController.navigate(screen.route) {
+                                    popUpTo(navController.graph.findStartDestination().id) { saveState = true }
+                                    launchSingleTop = true
+                                    restoreState = true
+                                }
+                            },
+                            icon = { Box(modifier = iconModifier) { screen.icon() } },
+                            label = { Text(screen.label) }
+                        )
+                    }
                 }
             }
         }
@@ -87,7 +90,7 @@ fun MainScreen() {
                 route = "detail/{id}",
                 arguments = listOf(navArgument("id") { type = NavType.IntType })
             ) {
-                FurnitureDetailRoute()
+                FurnitureDetailRoute(navController)
             }
         }
     }

--- a/app/src/main/java/pl/sofantastica/ui/detail/FurnitureDetailScreen.kt
+++ b/app/src/main/java/pl/sofantastica/ui/detail/FurnitureDetailScreen.kt
@@ -3,29 +3,32 @@ package pl.sofantastica.ui.detail
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
+import androidx.navigation.NavHostController
 import pl.sofantastica.data.model.FurnitureDto
 import pl.sofantastica.ui.common.UiState
 
 
 @Composable
 fun FurnitureDetailRoute(
+    navController: NavHostController,
     viewModel: FurnitureDetailViewModel = androidx.hilt.navigation.compose.hiltViewModel()
 ) {
     when (val state = viewModel.uiState) {
         is UiState.Loading -> Text("Loading...")
         is UiState.Error -> Text("Error: ${state.throwable.message}")
-        is UiState.Success -> FurnitureDetailScreen(state.data)
+        is UiState.Success -> FurnitureDetailScreen(item = state.data, onBack = { navController.popBackStack() })
     }
 }
 
 @Composable
-fun FurnitureDetailScreen(item: FurnitureDto) {
+fun FurnitureDetailScreen(item: FurnitureDto, onBack: () -> Unit) {
     Column(modifier = Modifier.padding(16.dp)) {
         AsyncImage(
             model = item.imageUrl,
@@ -34,6 +37,9 @@ fun FurnitureDetailScreen(item: FurnitureDto) {
         )
         Text(text = item.name, modifier = Modifier.padding(top = 8.dp))
         Text(text = item.description, modifier = Modifier.padding(top = 4.dp))
+        Button(onClick = onBack, modifier = Modifier.padding(top = 16.dp)) {
+            Text("Back")
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- hide bottom navigation bar when viewing furniture details
- add a back button to the furniture detail page

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685078ef07f08323990eb973475ec36a