### PR TITLE
Update catalog UI to card list

### DIFF
--- a/app/src/main/java/pl/sofantastica/ui/catalog/CatalogScreen.kt
+++ b/app/src/main/java/pl/sofantastica/ui/catalog/CatalogScreen.kt
@@ -1,24 +1,32 @@
 package pl.sofantastica.ui.catalog
 
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import pl.sofantastica.data.model.CategoryDto
 import pl.sofantastica.data.model.FurnitureDto
+import coil.compose.AsyncImage
+import kotlinx.coroutines.launch
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.tween
 
 @Composable
 fun CatalogRoute(
@@ -62,15 +70,47 @@ fun CatalogScreen(
             }
         }
 
+        val scope = rememberCoroutineScope()
         LazyColumn {
             items(furniture) { item ->
-                Text(
-                    text = item.name,
+                val scale = remember { Animatable(1f) }
+
+                Card(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .clickable { onItemClick(item.id) }
-                        .padding(8.dp)
-                )
+                        .padding(vertical = 4.dp)
+                        .graphicsLayer {
+                            scaleX = scale.value
+                            scaleY = scale.value
+                        }
+                        .clickable {
+                            scope.launch {
+                                scale.animateTo(0.95f, animationSpec = tween(100))
+                                scale.animateTo(1f, animationSpec = tween(100))
+                                onItemClick(item.id)
+                            }
+                        },
+                    shape = RoundedCornerShape(8.dp)
+                ) {
+                    Row(modifier = Modifier.padding(8.dp)) {
+                        AsyncImage(
+                            model = item.imageUrl,
+                            contentDescription = item.name,
+                            modifier = Modifier
+                                .size(80.dp)
+                                .clip(RoundedCornerShape(8.dp))
+                        )
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Column(modifier = Modifier.fillMaxWidth()) {
+                            Text(text = item.name, style = MaterialTheme.typography.titleMedium)
+                            Text(
+                                text = item.description,
+                                style = MaterialTheme.typography.bodyMedium,
+                                maxLines = 2
+                            )
+                        }
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- show catalog items as cards with the image on the left and info on the right
- animate each card on click before navigating to the detail page

## Testing
- `./gradlew tasks` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68507c41ec14832390868fc052887105